### PR TITLE
Some Moderation Commands + Fixes/Changes

### DIFF
--- a/core/src/main/java/moe/kyokobot/bot/command/CommandContext.java
+++ b/core/src/main/java/moe/kyokobot/bot/command/CommandContext.java
@@ -47,6 +47,10 @@ public class CommandContext {
         return event.getMember();
     }
 
+    public Member getSelfMember() {
+        return event.getGuild().getSelfMember();
+    }
+
     public TextChannel getChannel() {
         return event.getTextChannel();
     }

--- a/core/src/main/java/moe/kyokobot/bot/command/debug/GenDocsCommand.java
+++ b/core/src/main/java/moe/kyokobot/bot/command/debug/GenDocsCommand.java
@@ -5,6 +5,7 @@ import com.google.common.base.Joiner;
 import moe.kyokobot.bot.command.*;
 import moe.kyokobot.bot.manager.CommandManager;
 import moe.kyokobot.bot.util.StringUtil;
+import org.apache.commons.lang3.StringEscapeUtils;
 import org.jetbrains.annotations.NotNull;
 
 import java.io.IOException;
@@ -45,7 +46,7 @@ public class GenDocsCommand extends Command {
                     "\t\t\t\t\t<th style=\"width: 25%\" scope=\"col\">").append(context.getTranslated("generic.command")).append("</th>\n" +
                     "\t\t\t\t\t<th style=\"width: 25%\" scope=\"col\">").append(context.getTranslated("generic.aliases")).append("</th>\n" +
                     "\t\t\t\t\t<th style=\"width: 25%\" scope=\"col\">").append(context.getTranslated("generic.description")).append("</th>\n" +
-                    "\t\t\t\t\t<th style=\"width: 25%\" scope=\"col\">").append(context.getTranslated("generic.usage")).append("</th>\n" +
+                    "\t\t\t\t\t<th style=\"width: 25%\" scope=\"col\">").append(StringEscapeUtils.escapeHtml4(context.getTranslated("generic.usage"))).append("</th>\n" +
                     "\t\t\t\t</tr>\n" +
                     "\t\t\t</thead>\n" +
                     "\t\t\t<tbody>\n");
@@ -55,7 +56,7 @@ public class GenDocsCommand extends Command {
                         .append(cmd.getAliases() == null || cmd.getAliases().length == 0 ? "(" + context.getTranslated("generic.none") + ")" :
                                 Joiner.on(", ").join(cmd.getAliases())).append("</td>\n\t\t\t\t\t<td>")
                         .append(context.getTranslated(cmd.getDescription()).replaceAll("(\\b(https?|ftp|file)://[-a-zA-Z0-9+&@#/%?=~_|!:,.;]*[-a-zA-Z0-9+&@#/%=~_|])", "<a href=\"$1\">$1</a>")).append("</td>\n\t\t\t\t\t<td><code>")
-                        .append("ky!").append(cmd.getName()).append(" ").append(context.getTranslated(cmd.getUsage())).append("</code></td>\n\t\t\t\t</tr>\n");
+                        .append("ky!").append(cmd.getName()).append(" ").append(StringEscapeUtils.escapeHtml4(context.getTranslated(cmd.getUsage()))).append("</code></td>\n\t\t\t\t</tr>\n");
             });
             sb.append("\t\t\t</tbody>\n" +
                     "\t\t</table>\n" +

--- a/core/src/main/java/moe/kyokobot/bot/util/CommonErrors.java
+++ b/core/src/main/java/moe/kyokobot/bot/util/CommonErrors.java
@@ -4,6 +4,7 @@ import moe.kyokobot.bot.Constants;
 import moe.kyokobot.bot.Globals;
 import moe.kyokobot.bot.command.CommandContext;
 import moe.kyokobot.bot.command.CommandIcons;
+import net.dv8tion.jda.core.Permission;
 import net.dv8tion.jda.core.entities.Message;
 import net.dv8tion.jda.core.exceptions.PermissionException;
 
@@ -16,6 +17,10 @@ public class CommonErrors {
 
     public static void noPermissionBot(CommandContext context, PermissionException pex) {
         context.send(CommandIcons.ERROR + String.format(context.getTranslated("generic.botnoperm"), pex.getPermission().getName()));
+    }
+
+    public static void noPermissionBot(CommandContext context, Permission permission) {
+        context.send(CommandIcons.ERROR + String.format(context.getTranslated("generic.botnoperm"), permission.getName()));
     }
 
     public static void noUserFound(CommandContext context, String user) {

--- a/core/src/main/java/moe/kyokobot/bot/util/UserUtil.java
+++ b/core/src/main/java/moe/kyokobot/bot/util/UserUtil.java
@@ -27,8 +27,7 @@ public class UserUtil {
         return member.orElse(null);
     }
 
-    public static User getBannedUser(Guild guild, String arg) throws PermissionException {
-        //try {
+    public static Guild.Ban getBan(Guild guild, String arg) throws PermissionException {
         Optional<Guild.Ban> ban = guild.getBanList().complete().stream().parallel().filter(ftr ->
                 ftr.getUser().getAsMention().equals(arg)
                         || ftr.getUser().getName().equalsIgnoreCase(arg)
@@ -37,7 +36,7 @@ public class UserUtil {
                         || arg.equals("<@!" + ftr.getUser().getId() + ">")
                         || arg.equalsIgnoreCase(ftr.getUser().getName() + "#" + ftr.getUser().getDiscriminator())
                         || arg.equalsIgnoreCase("@" + ftr.getUser().getName() + "#" + ftr.getUser().getDiscriminator())).findFirst();
-        return ban.map(Guild.Ban::getUser).orElse(null);
+        return ban.orElse(null);
     }
 
     public static String toDiscrim(User u) {

--- a/core/src/main/resources/en-US/messages.properties
+++ b/core/src/main/resources/en-US/messages.properties
@@ -231,3 +231,7 @@ prefixes.title=Prefixes
 prefixes.default=Default prefix
 prefixes.guild=Guild prefixes
 prefixes.user=User prefixes
+moderation.usage=<member> [reason]
+moderation.kick.description=Kicks a member from this guild.
+moderation.kick.cannotkick=Cannot kick `%s` due to a lack of permissions.
+moderation.kick.output=Kicked `%s` for `%s`.

--- a/core/src/main/resources/en-US/messages.properties
+++ b/core/src/main/resources/en-US/messages.properties
@@ -244,3 +244,9 @@ moderation.ban.description=Bans a member from this guild.
 moderation.ban.cannotban=Cannot ban `%s` due to a lack of permissions.
 moderation.ban.output=Banned `%s` for `%s`. Purged messages up to %d day(s) ago.
 moderation.ban.error=Error when banning Guild Member `%s`: `%s`
+# Unban
+moderation.unban.usage=<member name>
+moderation.unban.description=Unbans a member from this guild.
+moderation.unban.cannotunban=Cannot unban `%s` due to a lack of permissions.
+moderation.unban.output=Unbanned `%s`, who was banned for `%s.`
+moderation.unban.error=Error when unbanning Guild Member `%s`: `%s`

--- a/core/src/main/resources/en-US/messages.properties
+++ b/core/src/main/resources/en-US/messages.properties
@@ -250,3 +250,4 @@ moderation.unban.description=Unbans a member from this guild.
 moderation.unban.cannotunban=Cannot unban `%s` due to a lack of permissions.
 moderation.unban.output=Unbanned `%s`, who was banned for `%s.`
 moderation.unban.error=Error when unbanning Guild Member `%s`: `%s`
+moderation.unban.nobanfound=Could not find a Banned User for the input `%s`.

--- a/core/src/main/resources/en-US/messages.properties
+++ b/core/src/main/resources/en-US/messages.properties
@@ -242,5 +242,5 @@ moderation.kick.error=Error when kicking Guild Member `%s`: `%s`
 moderation.ban.usage=<member> [purgeDays] [reason]
 moderation.ban.description=Bans a member from this guild.
 moderation.ban.cannotban=Cannot ban `%s` due to a lack of permissions.
-moderation.ban.output=Banned `%s` for `%s`.
+moderation.ban.output=Banned `%s` for `%s`, purged messages up to %d days ago.
 moderation.ban.error=Error when banning Guild Member `%s`: `%s`

--- a/core/src/main/resources/en-US/messages.properties
+++ b/core/src/main/resources/en-US/messages.properties
@@ -21,7 +21,6 @@ generic.cooldown=Wait a while before executing this command again!
 generic.enabled=enabled
 generic.disabled=disabled
 generic.votelock=This feature is available only if you have voted for Kyoko in last %d hours! Click here to vote: <%s>
-generic.nomessage=No message provided.
 api.alex.error=Error querying alexflipnote.xyz!
 api.nekoslife.error=Error querying nekos.life!
 api.weebsh.error=Error querying weeb.sh!
@@ -232,6 +231,9 @@ prefixes.title=Prefixes
 prefixes.default=Default prefix
 prefixes.guild=Guild prefixes
 prefixes.user=User prefixes
+# Generic
+# Remember to leave no full-stop/period (.) here
+moderation.noreason=No reason provided
 # Kick
 moderation.kick.usage=<member> [reason]
 moderation.kick.description=Kicks a member from this guild.
@@ -248,6 +250,6 @@ moderation.ban.error=Error when banning Guild Member `%s`: `%s`
 moderation.unban.usage=<member name>
 moderation.unban.description=Unbans a member from this guild.
 moderation.unban.cannotunban=Cannot unban `%s` due to a lack of permissions.
-moderation.unban.output=Unbanned `%s`, who was banned for `%s.`
+moderation.unban.output=Unbanned `%s`, who was banned for `%s`.
 moderation.unban.error=Error when unbanning Guild Member `%s`: `%s`
 moderation.unban.nobanfound=Could not find a Banned User for the input `%s`.

--- a/core/src/main/resources/en-US/messages.properties
+++ b/core/src/main/resources/en-US/messages.properties
@@ -21,6 +21,7 @@ generic.cooldown=Wait a while before executing this command again!
 generic.enabled=enabled
 generic.disabled=disabled
 generic.votelock=This feature is available only if you have voted for Kyoko in last %d hours! Click here to vote: <%s>
+generic.nomessage=No message provided.
 api.alex.error=Error querying alexflipnote.xyz!
 api.nekoslife.error=Error querying nekos.life!
 api.weebsh.error=Error querying weeb.sh!
@@ -231,7 +232,15 @@ prefixes.title=Prefixes
 prefixes.default=Default prefix
 prefixes.guild=Guild prefixes
 prefixes.user=User prefixes
-moderation.usage=<member> [reason]
+# Kick
+moderation.kick.usage=<member> [reason]
 moderation.kick.description=Kicks a member from this guild.
 moderation.kick.cannotkick=Cannot kick `%s` due to a lack of permissions.
 moderation.kick.output=Kicked `%s` for `%s`.
+moderation.kick.error=Error when kicking Guild Member `%s`: `%s`
+# Ban
+moderation.ban.usage=<member> [purgeDays] [reason]
+moderation.ban.description=Bans a member from this guild.
+moderation.ban.cannotban=Cannot ban `%s` due to a lack of permissions.
+moderation.ban.output=Banned `%s` for `%s`.
+moderation.ban.error=Error when banning Guild Member `%s`: `%s`

--- a/core/src/main/resources/en-US/messages.properties
+++ b/core/src/main/resources/en-US/messages.properties
@@ -242,5 +242,5 @@ moderation.kick.error=Error when kicking Guild Member `%s`: `%s`
 moderation.ban.usage=<member> [purgeDays] [reason]
 moderation.ban.description=Bans a member from this guild.
 moderation.ban.cannotban=Cannot ban `%s` due to a lack of permissions.
-moderation.ban.output=Banned `%s` for `%s`, purged messages up to %d days ago.
+moderation.ban.output=Banned `%s` for `%s`. Purged messages up to %d day(s) ago.
 moderation.ban.error=Error when banning Guild Member `%s`: `%s`

--- a/moderation/src/main/java/moe/kyokobot/moderation/ModerationIcons.kt
+++ b/moderation/src/main/java/moe/kyokobot/moderation/ModerationIcons.kt
@@ -1,0 +1,3 @@
+package moe.kyokobot.moderation
+
+const val BAN: String = "<:icbanhammer:472897776850567168>  |  "

--- a/moderation/src/main/java/moe/kyokobot/moderation/Module.java
+++ b/moderation/src/main/java/moe/kyokobot/moderation/Module.java
@@ -6,6 +6,7 @@ import moe.kyokobot.bot.manager.CommandManager;
 import moe.kyokobot.bot.manager.DatabaseManager;
 import moe.kyokobot.bot.module.KyokoModule;
 import moe.kyokobot.bot.util.EventWaiter;
+import moe.kyokobot.moderation.commands.KickCommand;
 import moe.kyokobot.moderation.commands.SettingsCommand;
 
 import java.util.ArrayList;
@@ -30,7 +31,7 @@ public class Module implements KyokoModule {
         commands = new ArrayList<>();
 
         commands.add(new SettingsCommand(eventWaiter, databaseManager));
-
+        commands.add(new KickCommand());
         commands.forEach(commandManager::registerCommand);
     }
 

--- a/moderation/src/main/java/moe/kyokobot/moderation/Module.java
+++ b/moderation/src/main/java/moe/kyokobot/moderation/Module.java
@@ -6,6 +6,7 @@ import moe.kyokobot.bot.manager.CommandManager;
 import moe.kyokobot.bot.manager.DatabaseManager;
 import moe.kyokobot.bot.module.KyokoModule;
 import moe.kyokobot.bot.util.EventWaiter;
+import moe.kyokobot.moderation.commands.BanCommand;
 import moe.kyokobot.moderation.commands.KickCommand;
 import moe.kyokobot.moderation.commands.SettingsCommand;
 
@@ -32,6 +33,7 @@ public class Module implements KyokoModule {
 
         commands.add(new SettingsCommand(eventWaiter, databaseManager));
         commands.add(new KickCommand());
+        commands.add(new BanCommand());
         commands.forEach(commandManager::registerCommand);
     }
 

--- a/moderation/src/main/java/moe/kyokobot/moderation/Module.java
+++ b/moderation/src/main/java/moe/kyokobot/moderation/Module.java
@@ -9,6 +9,7 @@ import moe.kyokobot.bot.util.EventWaiter;
 import moe.kyokobot.moderation.commands.BanCommand;
 import moe.kyokobot.moderation.commands.KickCommand;
 import moe.kyokobot.moderation.commands.SettingsCommand;
+import moe.kyokobot.moderation.commands.UnbanCommand;
 
 import java.util.ArrayList;
 
@@ -34,6 +35,7 @@ public class Module implements KyokoModule {
         commands.add(new SettingsCommand(eventWaiter, databaseManager));
         commands.add(new KickCommand());
         commands.add(new BanCommand());
+        commands.add(new UnbanCommand());
         commands.forEach(commandManager::registerCommand);
     }
 

--- a/moderation/src/main/java/moe/kyokobot/moderation/commands/BanCommand.kt
+++ b/moderation/src/main/java/moe/kyokobot/moderation/commands/BanCommand.kt
@@ -48,7 +48,7 @@ class BanCommand: Command() {
                 val arg = context.skipConcatArgs(2)
                 Pair(arg, arg)
             } else {
-                Pair(null, "No reason provided.")
+                Pair(null, "No reason provided")
             }
             val purgeDays: Int = if (context.args.size > 1) {
                 val arg = context.args[1]

--- a/moderation/src/main/java/moe/kyokobot/moderation/commands/BanCommand.kt
+++ b/moderation/src/main/java/moe/kyokobot/moderation/commands/BanCommand.kt
@@ -7,6 +7,7 @@ import moe.kyokobot.bot.command.CommandContext
 import moe.kyokobot.bot.command.CommandIcons
 import moe.kyokobot.bot.util.CommonErrors
 import moe.kyokobot.bot.util.UserUtil
+import moe.kyokobot.moderation.BAN
 import net.dv8tion.jda.core.Permission
 import net.dv8tion.jda.core.entities.Member
 
@@ -65,7 +66,7 @@ class BanCommand: Command() {
 
             context.guild.controller.ban(member, purgeDays, reasonObj).queue({
                 val translated = String.format(context.getTranslated("moderation.ban.output"), formattedName, reasonString, purgeDays)
-                context.send("${CommandIcons.SUCCESS}$translated")
+                context.send("$BAN$translated")
             }) { err ->
                 Sentry.capture(err)
                 val error = String.format(context.getTranslated("moderation.ban.error"), formattedName, err.message)

--- a/moderation/src/main/java/moe/kyokobot/moderation/commands/BanCommand.kt
+++ b/moderation/src/main/java/moe/kyokobot/moderation/commands/BanCommand.kt
@@ -44,24 +44,25 @@ class BanCommand: Command() {
             return
         }
         try {
-            val (reasonObj, reasonString) = if (context.args.size > 2) {
-                val arg = context.skipConcatArgs(2)
-                Pair(arg, arg)
-            } else {
-                Pair(null, "No reason provided")
-            }
-            val purgeDays: Int = if (context.args.size > 1) {
+            val (number, purgeDays) = if (context.args.size > 1) {
                 val arg = context.args[1]
                 try {
-                    Integer.parseUnsignedInt(arg)
+                    Pair(2, Integer.parseUnsignedInt(arg))
                 } catch (err: NumberFormatException) {
-                    CommonErrors.notANumber(context, arg)
-                    return
+                    Pair(1, 0)
                 }
             }
             else {
-                0
+                Pair(1, 0)
             }
+
+            val (reasonObj, reasonString) = if (context.args.size > number) {
+                val arg = context.skipConcatArgs(number)
+                Pair(arg, arg)
+            } else {
+                Pair(null, context.getTranslated("moderation.noreason"))
+            }
+
             context.guild.controller.ban(member, purgeDays, reasonObj).queue({
                 val translated = String.format(context.getTranslated("moderation.ban.output"), formattedName, reasonString, purgeDays)
                 context.send("${CommandIcons.SUCCESS}$translated")

--- a/moderation/src/main/java/moe/kyokobot/moderation/commands/BanCommand.kt
+++ b/moderation/src/main/java/moe/kyokobot/moderation/commands/BanCommand.kt
@@ -1,0 +1,79 @@
+package moe.kyokobot.moderation.commands
+
+import io.sentry.Sentry
+import moe.kyokobot.bot.command.Command
+import moe.kyokobot.bot.command.CommandCategory
+import moe.kyokobot.bot.command.CommandContext
+import moe.kyokobot.bot.command.CommandIcons
+import moe.kyokobot.bot.util.CommonErrors
+import moe.kyokobot.bot.util.UserUtil
+import net.dv8tion.jda.core.Permission
+import net.dv8tion.jda.core.entities.Member
+
+class BanCommand: Command() {
+    init {
+        name = "ban"
+        description = "moderation.ban.description"
+        usage = "moderation.ban.usage"
+        category = CommandCategory.MODERATION
+    }
+
+    override fun execute(context: CommandContext) {
+        if (!context.selfMember.hasPermission(Permission.BAN_MEMBERS)) {
+            CommonErrors.noPermissionBot(context, Permission.BAN_MEMBERS)
+            return
+        }
+        if (!context.member.hasPermission(Permission.BAN_MEMBERS)) {
+            CommonErrors.noPermissionUser(context)
+            return
+        }
+        if (!context.hasArgs()) {
+            CommonErrors.usage(context)
+            return
+        }
+        val memberName = context.args[0]
+        val member: Member? = UserUtil.getMember(context.guild, memberName)
+        if (member == null) {
+            CommonErrors.noUserFound(context, memberName)
+            return
+        }
+        val formattedName = "${member.user.name}#${member.user.discriminator}"
+        if (!context.member.canInteract(member)) {
+            val name = String.format(context.getTranslated("moderation.ban.cannotban"), formattedName)
+            context.send("${CommandIcons.ERROR}$name")
+            return
+        }
+        try {
+            val (reasonObj, reasonString) = if (context.args.size > 2) {
+                val arg = context.skipConcatArgs(2)
+                Pair(arg, arg)
+            } else {
+                Pair(null, "No reason provided.")
+            }
+            val purgeDays: Int = if (context.args.size > 1) {
+                val arg = context.args[1]
+                try {
+                    Integer.parseUnsignedInt(arg)
+                } catch (err: NumberFormatException) {
+                    CommonErrors.notANumber(context, arg)
+                    return
+                }
+            }
+            else {
+                0
+            }
+            context.guild.controller.ban(member, purgeDays, reasonObj).queue({
+                val translated = String.format(context.getTranslated("moderation.ban.output"), formattedName, reasonString, purgeDays)
+                context.send("${CommandIcons.SUCCESS}$translated")
+            }) { err ->
+                Sentry.capture(err)
+                val error = String.format(context.getTranslated("moderation.ban.error"), formattedName, err.message)
+                context.send("${CommandIcons.ERROR}$error")
+            }
+        } catch (err: Throwable) {
+            Sentry.capture(err)
+            val error = String.format(context.getTranslated("moderation.ban.error"), formattedName, err.message)
+            context.send("${CommandIcons.ERROR}$error")
+        }
+    }
+}

--- a/moderation/src/main/java/moe/kyokobot/moderation/commands/KickCommand.kt
+++ b/moderation/src/main/java/moe/kyokobot/moderation/commands/KickCommand.kt
@@ -45,7 +45,7 @@ class KickCommand: Command() {
         }
         try {
             val (reasonObj, reasonString) = if (context.args.size > 1) {
-                val arg = context.args[1]
+                val arg = context.skipConcatArgs(1)
                 Pair(arg, arg)
             } else {
                 Pair(null, "No reason provided.")

--- a/moderation/src/main/java/moe/kyokobot/moderation/commands/KickCommand.kt
+++ b/moderation/src/main/java/moe/kyokobot/moderation/commands/KickCommand.kt
@@ -14,7 +14,7 @@ class KickCommand: Command() {
     init {
         name = "kick"
         description = "moderation.kick.description"
-        usage = "moderation.usage"
+        usage = "moderation.kick.usage"
         category = CommandCategory.MODERATION
     }
 
@@ -55,11 +55,13 @@ class KickCommand: Command() {
                 context.send("${CommandIcons.SUCCESS}$translated")
             }) { err ->
                 Sentry.capture(err)
-                context.send("${CommandIcons.ERROR}Error when kicking Guild Member $formattedName: ${err.message}")
+                val error = String.format(context.getTranslated("moderation.kick.error"), formattedName, err.message)
+                context.send("${CommandIcons.ERROR}$error")
             }
         } catch (err: Throwable) {
             Sentry.capture(err)
-            context.send("${CommandIcons.ERROR}Error when kicking Guild Member $formattedName: ${err.message}")
+            val error = String.format(context.getTranslated("moderation.kick.error"), formattedName, err.message)
+            context.send("${CommandIcons.ERROR}$error")
         }
     }
 }

--- a/moderation/src/main/java/moe/kyokobot/moderation/commands/KickCommand.kt
+++ b/moderation/src/main/java/moe/kyokobot/moderation/commands/KickCommand.kt
@@ -1,0 +1,65 @@
+package moe.kyokobot.moderation.commands
+
+import io.sentry.Sentry
+import moe.kyokobot.bot.command.Command
+import moe.kyokobot.bot.command.CommandCategory
+import moe.kyokobot.bot.command.CommandContext
+import moe.kyokobot.bot.command.CommandIcons
+import moe.kyokobot.bot.util.CommonErrors
+import moe.kyokobot.bot.util.UserUtil
+import net.dv8tion.jda.core.Permission
+import net.dv8tion.jda.core.entities.Member
+
+class KickCommand: Command() {
+    init {
+        name = "kick"
+        description = "moderation.kick.description"
+        usage = "moderation.usage"
+        category = CommandCategory.MODERATION
+    }
+
+    override fun execute(context: CommandContext) {
+        if (!context.selfMember.hasPermission(Permission.KICK_MEMBERS)) {
+            CommonErrors.noPermissionBot(context, Permission.KICK_MEMBERS)
+            return
+        }
+        if (!context.member.hasPermission(Permission.KICK_MEMBERS)) {
+            CommonErrors.noPermissionUser(context)
+            return
+        }
+        if (!context.hasArgs()) {
+            CommonErrors.usage(context)
+            return
+        }
+        val memberName = context.args[0]
+        val member: Member? = UserUtil.getMember(context.guild, memberName)
+        if (member == null) {
+            CommonErrors.noUserFound(context, memberName)
+            return
+        }
+        val formattedName = "${member.user.name}#${member.user.discriminator}"
+        if (!context.member.canInteract(member)) {
+            val name = String.format(context.getTranslated("moderation.kick.cannotkick"), formattedName)
+            context.send("${CommandIcons.ERROR}$name")
+            return
+        }
+        try {
+            val (reasonObj, reasonString) = if (context.args.size > 1) {
+                val arg = context.args[1]
+                Pair(arg, arg)
+            } else {
+                Pair(null, "No reason provided.")
+            }
+            context.guild.controller.kick(member, reasonObj).queue({
+                val translated = String.format(context.getTranslated("moderation.kick.output"), formattedName, reasonString)
+                context.send("${CommandIcons.SUCCESS}$translated")
+            }) { err ->
+                Sentry.capture(err)
+                context.send("${CommandIcons.ERROR}Error when kicking Guild Member $formattedName: ${err.message}")
+            }
+        } catch (err: Throwable) {
+            Sentry.capture(err)
+            context.send("${CommandIcons.ERROR}Error when kicking Guild Member $formattedName: ${err.message}")
+        }
+    }
+}

--- a/moderation/src/main/java/moe/kyokobot/moderation/commands/UnbanCommand.kt
+++ b/moderation/src/main/java/moe/kyokobot/moderation/commands/UnbanCommand.kt
@@ -15,6 +15,7 @@ class UnbanCommand: Command() {
         description = "moderation.unban.description"
         usage = "moderation.unban.usage"
         category = CommandCategory.MODERATION
+        aliases = arrayOf("pardon")
     }
 
     override fun execute(context: CommandContext) {

--- a/moderation/src/main/java/moe/kyokobot/moderation/commands/UnbanCommand.kt
+++ b/moderation/src/main/java/moe/kyokobot/moderation/commands/UnbanCommand.kt
@@ -40,7 +40,8 @@ class UnbanCommand: Command() {
         val formattedName = "${ban.user.name}#${ban.user.discriminator}"
         try {
             context.guild.controller.unban(ban.user).queue({
-                val translated = String.format(context.getTranslated("moderation.unban.output"), formattedName, ban.reason)
+                val translated = String.format(context.getTranslated("moderation.unban.output"), formattedName,
+                        ban.reason ?: context.getTranslated("moderation.noreason"))
                 context.send("${CommandIcons.SUCCESS}$translated")
             }) { err ->
                 Sentry.capture(err)

--- a/moderation/src/main/java/moe/kyokobot/moderation/commands/UnbanCommand.kt
+++ b/moderation/src/main/java/moe/kyokobot/moderation/commands/UnbanCommand.kt
@@ -1,0 +1,56 @@
+package moe.kyokobot.moderation.commands
+
+import io.sentry.Sentry
+import moe.kyokobot.bot.command.Command
+import moe.kyokobot.bot.command.CommandCategory
+import moe.kyokobot.bot.command.CommandContext
+import moe.kyokobot.bot.command.CommandIcons
+import moe.kyokobot.bot.util.CommonErrors
+import moe.kyokobot.bot.util.UserUtil
+import net.dv8tion.jda.core.Permission
+
+class UnbanCommand: Command() {
+    init {
+        name = "unban"
+        description = "moderation.unban.description"
+        usage = "moderation.unban.usage"
+        category = CommandCategory.MODERATION
+    }
+
+    override fun execute(context: CommandContext) {
+        if (!context.selfMember.hasPermission(Permission.BAN_MEMBERS)) {
+            CommonErrors.noPermissionBot(context, Permission.BAN_MEMBERS)
+            return
+        }
+        if (!context.member.hasPermission(Permission.BAN_MEMBERS)) {
+            CommonErrors.noPermissionUser(context)
+            return
+        }
+        if (!context.hasArgs()) {
+            CommonErrors.usage(context)
+            return
+        }
+        val name = context.args[0]
+        val ban = UserUtil.getBan(context.guild, name)
+        if (ban == null) {
+            val translated = String.format(context.getTranslated("moderation.unban.nobanfound"), name)
+            context.send("${CommandIcons.ERROR}$translated")
+            return
+        }
+        val formattedName = "${ban.user.name}#${ban.user.discriminator}"
+        try {
+            context.guild.controller.unban(ban.user).queue({
+                val translated = String.format(context.getTranslated("moderation.unban.output"), formattedName, ban.reason)
+                context.send("${CommandIcons.SUCCESS}$translated")
+            }) { err ->
+                Sentry.capture(err)
+                val error = String.format(context.getTranslated("moderation.unban.error"), formattedName, err.message)
+                context.send("${CommandIcons.ERROR}$error")
+            }
+        } catch (err: Throwable) {
+            Sentry.capture(err)
+            val error = String.format(context.getTranslated("moderation.unban.error"), formattedName, err.message)
+            context.send("${CommandIcons.ERROR}$error")
+        }
+    }
+}


### PR DESCRIPTION
**all these changes have been tested locally**

- added a `ModerationIcons` file which holds constant icons. these are top level kotlin constants, so in java you'll have to access them via the "class" `ModerationIconsKt`
- added some helper methods to `CommandContext`, `UserUtil` and `CommonErrors`
- fixed the gendocs debug command so it escapes html chars for usage descriptions
- added kick, ban and unban commands with the appropriate translation strings too