### PR TITLE
Prune Command + Translation Strings + ModerationCommand Class

### DIFF
--- a/core/src/main/resources/en-US/messages.properties
+++ b/core/src/main/resources/en-US/messages.properties
@@ -253,3 +253,10 @@ moderation.unban.cannotunban=Cannot unban `%s` due to a lack of permissions.
 moderation.unban.output=Unbanned `%s`, who was banned for `%s`.
 moderation.unban.error=Error when unbanning Guild Member `%s`: `%s`
 moderation.unban.nobanfound=Could not find a Banned User for the input `%s`.
+# Clear
+moderation.clear.usage=[amount]=15 [member1 member2 ...]=all
+moderation.clear.description=Clears up-to 100 messages from certain (or all) members.
+moderation.clear.cannotclearprivate=Messages can only be cleared in Guild Channels.
+moderation.clear.cannotcleartime=Only messages from earlier than 2 weeks ago can be cleared.
+moderation.clear.cannotclear=Cannot clear messages due to a lack of permissions.
+moderation.clear.output=Cleared %d messages from %d members.

--- a/core/src/main/resources/en-US/messages.properties
+++ b/core/src/main/resources/en-US/messages.properties
@@ -159,7 +159,7 @@ music.skip.description=Skips currently playing song.
 music.repeat.description=Toggles current song repeating.
 music.pause.description=Pauses currently playing song.
 music.resume.description=Resumes track if it got paused.
-music.stop.description=Stops music playback and clears queue.
+music.stop.description=Stops music playback and prunes queue.
 music.nightcore.description=Toggles nightcore mode and changes it's speed.
 music.karaoke.description=Toggles karaoke mode.
 music.vaporwave.description=Toggles vaporwave mode.
@@ -253,9 +253,10 @@ moderation.unban.cannotunban=Cannot unban `%s` due to a lack of permissions.
 moderation.unban.output=Unbanned `%s`, who was banned for `%s`.
 moderation.unban.error=Error when unbanning Guild Member `%s`: `%s`
 moderation.unban.nobanfound=Could not find a Banned User for the input `%s`.
-# Clear
-moderation.clear.usage=[amount]=15 [member1 member2 ...]=all
-moderation.clear.description=Clears up-to 100 messages from certain (or all) members.
-moderation.clear.cannotclearprivate=Messages can only be cleared in Guild Channels.
-moderation.clear.cannotclearnumber=Kyoko can only clear up to 100 messages at a time.
-moderation.clear.output=Cleared %d message(s) from %d member(s).
+# Prune
+moderation.prune.usage=[amount]=15 [member1 member2 ...]=all
+moderation.prune.descriptio=Prunes up-to 100 messages from certain (or all) members.
+moderation.prune.cannotpruneprivate=Messages can only be pruned in Guild Channels.
+moderation.prune.cannotprunenumber=Kyoko can only prune up to 100 messages at a time.
+moderation.prune.output=Pruned %d message(s) from %d member(s).
+moderation.prune.errorcleaningself=Error when attempting to clean up the clear message.

--- a/core/src/main/resources/en-US/messages.properties
+++ b/core/src/main/resources/en-US/messages.properties
@@ -257,7 +257,5 @@ moderation.unban.nobanfound=Could not find a Banned User for the input `%s`.
 moderation.clear.usage=[amount]=15 [member1 member2 ...]=all
 moderation.clear.description=Clears up-to 100 messages from certain (or all) members.
 moderation.clear.cannotclearprivate=Messages can only be cleared in Guild Channels.
-moderation.clear.cannotcleartime=Only messages from earlier than 2 weeks ago can be cleared.
 moderation.clear.cannotclearnumber=Kyoko can only clear up to 100 messages at a time.
-moderation.clear.cannotclear=Cannot clear messages due to a lack of permissions.
-moderation.clear.output=Cleared %d messages from %d members.
+moderation.clear.output=Cleared %d message(s) from %d member(s).

--- a/core/src/main/resources/en-US/messages.properties
+++ b/core/src/main/resources/en-US/messages.properties
@@ -258,5 +258,6 @@ moderation.clear.usage=[amount]=15 [member1 member2 ...]=all
 moderation.clear.description=Clears up-to 100 messages from certain (or all) members.
 moderation.clear.cannotclearprivate=Messages can only be cleared in Guild Channels.
 moderation.clear.cannotcleartime=Only messages from earlier than 2 weeks ago can be cleared.
+moderation.clear.cannotclearnumber=Kyoko can only clear up to 100 messages at a time.
 moderation.clear.cannotclear=Cannot clear messages due to a lack of permissions.
 moderation.clear.output=Cleared %d messages from %d members.

--- a/core/src/main/resources/en-US/messages.properties
+++ b/core/src/main/resources/en-US/messages.properties
@@ -254,9 +254,10 @@ moderation.unban.output=Unbanned `%s`, who was banned for `%s`.
 moderation.unban.error=Error when unbanning Guild Member `%s`: `%s`
 moderation.unban.nobanfound=Could not find a Banned User for the input `%s`.
 # Prune
-moderation.prune.usage=[amount]=15 [member1 member2 ...]=all
-moderation.prune.descriptio=Prunes up-to 100 messages from certain (or all) members.
+moderation.prune.usage=[amount]=15 [member1 member2 bots...]|[contains some content]=all
+moderation.prune.description=Prunes up-to 100 messages from certain (or all) members, or messages that contain some content.
 moderation.prune.cannotpruneprivate=Messages can only be pruned in Guild Channels.
 moderation.prune.cannotprunenumber=Kyoko can only prune up to 100 messages at a time.
 moderation.prune.output=Pruned %d message(s) from %d member(s).
 moderation.prune.errorcleaningself=Error when attempting to clean up the clear message.
+moderation.prune.containserror=You must specify what messages have to contain to be deleted.

--- a/core/src/main/resources/en-US/messages.properties
+++ b/core/src/main/resources/en-US/messages.properties
@@ -256,7 +256,6 @@ moderation.unban.nobanfound=Could not find a Banned User for the input `%s`.
 # Prune
 moderation.prune.usage=[amount]=15 [member1 member2 bots...]|[contains some content]=all
 moderation.prune.description=Prunes up-to 100 messages from certain (or all) members, or messages that contain some content.
-moderation.prune.cannotpruneprivate=Messages can only be pruned in Guild Channels.
 moderation.prune.cannotprunenumber=Kyoko can only prune up to 100 messages at a time.
 moderation.prune.output=Pruned %d message(s) from %d member(s).
 moderation.prune.errorcleaningself=Error when attempting to clean up the clear message.

--- a/moderation/src/main/java/moe/kyokobot/moderation/ModerationCommand.kt
+++ b/moderation/src/main/java/moe/kyokobot/moderation/ModerationCommand.kt
@@ -36,4 +36,6 @@ open class ModerationCommand(name: String, private vararg val permissions: Permi
             return
         super.preExecute(context)
     }
+
+    fun getTranslated(context: CommandContext, key: String, vararg params: Any = emptyArray()): String? = context.getTranslated("moderation.$name.$key")?.format(params)
 }

--- a/moderation/src/main/java/moe/kyokobot/moderation/ModerationCommand.kt
+++ b/moderation/src/main/java/moe/kyokobot/moderation/ModerationCommand.kt
@@ -1,0 +1,39 @@
+package moe.kyokobot.moderation
+
+import moe.kyokobot.bot.command.Command
+import moe.kyokobot.bot.command.CommandCategory
+import moe.kyokobot.bot.command.CommandContext
+import moe.kyokobot.bot.util.CommonErrors
+import net.dv8tion.jda.core.Permission
+
+open class ModerationCommand(name: String, private vararg val permissions: Permission = emptyArray(), private val hasArgs: Boolean = true): Command() {
+    init {
+        super.name = name
+        description = "moderation.$name.description"
+        usage = "moderation.$name.usage"
+        category = CommandCategory.MODERATION
+    }
+
+    override fun preExecute(context: CommandContext) {
+        if (hasArgs && !context.hasArgs()) {
+            CommonErrors.usage(context)
+            return
+        }
+        if (context.member.hasPermission(*permissions)) {
+            CommonErrors.noPermissionUser(context)
+            return
+        }
+        /* -- An iterator is used over varargs here so I can get the specific permission the bot lacks. -- */
+        var failed = false
+        permissions.forEach { perm ->
+            if (!context.selfMember.hasPermission(perm)) {
+                CommonErrors.noPermissionBot(context, perm)
+                failed = true
+                return
+            }
+        }
+        if (failed)
+            return
+        super.preExecute(context)
+    }
+}

--- a/moderation/src/main/java/moe/kyokobot/moderation/ModerationCommand.kt
+++ b/moderation/src/main/java/moe/kyokobot/moderation/ModerationCommand.kt
@@ -19,8 +19,14 @@ open class ModerationCommand(name: String, private vararg val permissions: Permi
             CommonErrors.usage(context)
             return
         }
-        if (context.member.hasPermission(*permissions)) {
-            CommonErrors.noPermissionUser(context)
+        if (!context.member.hasPermission(Permission.ADMINISTRATOR)) {
+            if (context.member.hasPermission(*permissions)) {
+                CommonErrors.noPermissionUser(context)
+                return
+            }
+        }
+        if (context.selfMember.hasPermission(Permission.ADMINISTRATOR)) {
+            super.preExecute(context)
             return
         }
         /* -- An iterator is used over varargs here so I can get the specific permission the bot lacks. -- */
@@ -37,5 +43,6 @@ open class ModerationCommand(name: String, private vararg val permissions: Permi
         super.preExecute(context)
     }
 
-    fun getTranslated(context: CommandContext, key: String, vararg params: Any = emptyArray()): String? = context.getTranslated("moderation.$name.$key")?.format(params)
+    fun getTranslated(context: CommandContext, key: String, vararg params: Any? = emptyArray()): String? =
+            context.getTranslated("moderation.$name.$key")?.format(*params)
 }

--- a/moderation/src/main/java/moe/kyokobot/moderation/Module.java
+++ b/moderation/src/main/java/moe/kyokobot/moderation/Module.java
@@ -6,10 +6,7 @@ import moe.kyokobot.bot.manager.CommandManager;
 import moe.kyokobot.bot.manager.DatabaseManager;
 import moe.kyokobot.bot.module.KyokoModule;
 import moe.kyokobot.bot.util.EventWaiter;
-import moe.kyokobot.moderation.commands.BanCommand;
-import moe.kyokobot.moderation.commands.KickCommand;
-import moe.kyokobot.moderation.commands.SettingsCommand;
-import moe.kyokobot.moderation.commands.UnbanCommand;
+import moe.kyokobot.moderation.commands.*;
 
 import java.util.ArrayList;
 
@@ -36,6 +33,7 @@ public class Module implements KyokoModule {
         commands.add(new KickCommand());
         commands.add(new BanCommand());
         commands.add(new UnbanCommand());
+        commands.add(new PruneCommand());
         commands.forEach(commandManager::registerCommand);
     }
 

--- a/moderation/src/main/java/moe/kyokobot/moderation/commands/BanCommand.kt
+++ b/moderation/src/main/java/moe/kyokobot/moderation/commands/BanCommand.kt
@@ -1,37 +1,17 @@
 package moe.kyokobot.moderation.commands
 
 import io.sentry.Sentry
-import moe.kyokobot.bot.command.Command
-import moe.kyokobot.bot.command.CommandCategory
 import moe.kyokobot.bot.command.CommandContext
 import moe.kyokobot.bot.command.CommandIcons
 import moe.kyokobot.bot.util.CommonErrors
 import moe.kyokobot.bot.util.UserUtil
+import moe.kyokobot.moderation.ModerationCommand
 import moe.kyokobot.moderation.ModerationIcons.BAN
 import net.dv8tion.jda.core.Permission
 import net.dv8tion.jda.core.entities.Member
 
-class BanCommand: Command() {
-    init {
-        name = "ban"
-        description = "moderation.ban.description"
-        usage = "moderation.ban.usage"
-        category = CommandCategory.MODERATION
-    }
-
+class BanCommand: ModerationCommand("ban", Permission.BAN_MEMBERS) {
     override fun execute(context: CommandContext) {
-        if (!context.selfMember.hasPermission(Permission.BAN_MEMBERS)) {
-            CommonErrors.noPermissionBot(context, Permission.BAN_MEMBERS)
-            return
-        }
-        if (!context.member.hasPermission(Permission.BAN_MEMBERS)) {
-            CommonErrors.noPermissionUser(context)
-            return
-        }
-        if (!context.hasArgs()) {
-            CommonErrors.usage(context)
-            return
-        }
         val memberName = context.args[0]
         val member: Member? = UserUtil.getMember(context.guild, memberName)
         if (member == null) {

--- a/moderation/src/main/java/moe/kyokobot/moderation/commands/KickCommand.kt
+++ b/moderation/src/main/java/moe/kyokobot/moderation/commands/KickCommand.kt
@@ -1,36 +1,16 @@
 package moe.kyokobot.moderation.commands
 
 import io.sentry.Sentry
-import moe.kyokobot.bot.command.Command
-import moe.kyokobot.bot.command.CommandCategory
 import moe.kyokobot.bot.command.CommandContext
 import moe.kyokobot.bot.command.CommandIcons
 import moe.kyokobot.bot.util.CommonErrors
 import moe.kyokobot.bot.util.UserUtil
+import moe.kyokobot.moderation.ModerationCommand
 import net.dv8tion.jda.core.Permission
 import net.dv8tion.jda.core.entities.Member
 
-class KickCommand: Command() {
-    init {
-        name = "kick"
-        description = "moderation.kick.description"
-        usage = "moderation.kick.usage"
-        category = CommandCategory.MODERATION
-    }
-
+class KickCommand: ModerationCommand("kick", Permission.KICK_MEMBERS) {
     override fun execute(context: CommandContext) {
-        if (!context.selfMember.hasPermission(Permission.KICK_MEMBERS)) {
-            CommonErrors.noPermissionBot(context, Permission.KICK_MEMBERS)
-            return
-        }
-        if (!context.member.hasPermission(Permission.KICK_MEMBERS)) {
-            CommonErrors.noPermissionUser(context)
-            return
-        }
-        if (!context.hasArgs()) {
-            CommonErrors.usage(context)
-            return
-        }
         val memberName = context.args[0]
         val member: Member? = UserUtil.getMember(context.guild, memberName)
         if (member == null) {

--- a/moderation/src/main/java/moe/kyokobot/moderation/commands/PruneCommand.kt
+++ b/moderation/src/main/java/moe/kyokobot/moderation/commands/PruneCommand.kt
@@ -16,7 +16,7 @@ import java.time.temporal.ChronoUnit
 import java.util.concurrent.TimeUnit
 import java.util.stream.Collectors
 
-class PruneCommand: ModerationCommand("prune", Permission.MESSAGE_HISTORY, Permission.MESSAGE_MANAGE) {
+class PruneCommand: ModerationCommand("prune", Permission.MESSAGE_HISTORY, Permission.MESSAGE_MANAGE, hasArgs = false) {
     override fun execute(context: CommandContext) {
         val args = context.args
         val size = args.size

--- a/moderation/src/main/java/moe/kyokobot/moderation/commands/PruneCommand.kt
+++ b/moderation/src/main/java/moe/kyokobot/moderation/commands/PruneCommand.kt
@@ -38,7 +38,7 @@ class PruneCommand: ModerationCommand("prune", Permission.MESSAGE_HISTORY, Permi
             finally {
                 if (size > number) {
                     val contains = args[number]
-                    if (contains.equals("contains", true)) {
+                    if (contains.equals("contains", true) || contains.equals("-contains", true)) {
                         if (size > number + 1) {
                             containMode = true
                         } else {
@@ -64,7 +64,7 @@ class PruneCommand: ModerationCommand("prune", Permission.MESSAGE_HISTORY, Permi
                     .asSequence()
                     .drop(number)
                     .map { str ->
-                        if (str.equals("bots", true) && !addedBots) {
+                        if (str.equals("bots", true) || str.equals("-bots", true) && !addedBots) {
                             context.guild.members
                                     .filter { it.user.isBot }
                                     .forEach { set.add(it.user.idLong) }

--- a/moderation/src/main/java/moe/kyokobot/moderation/commands/PruneCommand.kt
+++ b/moderation/src/main/java/moe/kyokobot/moderation/commands/PruneCommand.kt
@@ -83,9 +83,10 @@ class PruneCommand: Command() {
             null
         }
         val timestamp = MiscUtil.getDiscordTimestamp(System.currentTimeMillis()).toString()
-        MessageHistory.getHistoryBefore(context.channel, timestamp).limit(amountToClear).queue({ history ->
+        MessageHistory.getHistoryBefore(context.channel, timestamp).limit(amountToClear + 1).queue({ history ->
             val filtered = history.retrievedHistory
                     .stream()
+                    .skip(1)
                     .filter { msg ->
                         (shouldAllowAll || mentioned!!.contains(msg.author.idLong))
                                 && ChronoUnit.WEEKS.between(msg.creationTime, OffsetDateTime.now()) < 2
@@ -129,8 +130,9 @@ class PruneCommand: Command() {
             }
         }
     }
-    private fun handleError(context: CommandContext, err: Throwable) {
-        val translated = String.format(context.getTranslated("moderation.prune.error"), err.message)
+    private fun handleError(context: CommandContext, err: Throwable, self: Boolean = false) {
+        val str = if (!self) "moderation.prune.error" else "moderation.prune.errorcleaningself"
+        val translated = String.format(context.getTranslated(str), err.message)
         Sentry.capture(err)
         context.send("${CommandIcons.ERROR}$translated")
     }

--- a/moderation/src/main/java/moe/kyokobot/moderation/commands/PruneCommand.kt
+++ b/moderation/src/main/java/moe/kyokobot/moderation/commands/PruneCommand.kt
@@ -1,0 +1,137 @@
+package moe.kyokobot.moderation.commands
+
+import io.sentry.Sentry
+import it.unimi.dsi.fastutil.longs.LongOpenHashSet
+import it.unimi.dsi.fastutil.longs.LongSet
+import moe.kyokobot.bot.command.Command
+import moe.kyokobot.bot.command.CommandContext
+import moe.kyokobot.bot.command.CommandIcons
+import moe.kyokobot.bot.util.CommonErrors
+import moe.kyokobot.bot.util.UserUtil
+import net.dv8tion.jda.core.Permission
+import net.dv8tion.jda.core.entities.ChannelType
+import net.dv8tion.jda.core.entities.Message
+import net.dv8tion.jda.core.entities.MessageHistory
+import net.dv8tion.jda.core.utils.MiscUtil
+import java.time.OffsetDateTime
+import java.time.temporal.ChronoUnit
+import java.util.concurrent.TimeUnit
+import java.util.stream.Collectors
+
+class PruneCommand: Command() {
+    init {
+        name = "prune"
+        description = "moderation.prune.description"
+        usage = "moderation.prune.usage"
+    }
+
+    override fun execute(context: CommandContext) {
+        if (!context.message.isFromType(ChannelType.TEXT)) {
+            val translated = context.getTranslated("moderation.prune.cannotpruneprivate")
+            context.send("${CommandIcons.ERROR}$translated")
+            return
+        }
+        if (!context.selfMember.hasPermission(Permission.MESSAGE_MANAGE)) {
+            CommonErrors.noPermissionBot(context, Permission.MESSAGE_MANAGE)
+            return
+        }
+        if (!context.selfMember.hasPermission(Permission.MESSAGE_HISTORY)) {
+            CommonErrors.noPermissionBot(context, Permission.MESSAGE_HISTORY)
+            return
+        }
+        if (!context.member.hasPermission(Permission.MESSAGE_MANAGE) || !context.member.hasPermission(Permission.MESSAGE_HISTORY)) {
+            CommonErrors.noPermissionUser(context)
+            return
+        }
+        val (number, amountToClear) = if (context.hasArgs()) {
+            try {
+                val arg = context.args[0]
+                val num = Integer.parseUnsignedInt(arg)
+                if (num > 100) {
+                    val translated = context.getTranslated("moderation.prune.cannotprunenumber")
+                    context.send("${CommandIcons.ERROR}$translated")
+                    return
+                }
+                Pair(1, num)
+            } catch (err: NumberFormatException) {
+                Pair(0, 15)
+            }
+        } else {
+            Pair(-1, 15)
+        }
+        if (amountToClear == 0) {
+            val translated = String.format(context.getTranslated("moderation.prune.output"), 0, 0)
+            context.send("${CommandIcons.SUCCESS}$translated")
+            return
+        }
+        var shouldAllowAll = true
+        val mentioned: LongSet? = if (number != -1 && context.args.size > number) {
+            val set = LongOpenHashSet()
+            context.args
+                    .asSequence()
+                    .drop(number)
+                    .map { str ->
+                        val id = UserUtil.getMember(context.guild, str)?.user?.idLong
+                        if (id != null) {
+                            shouldAllowAll = false
+                            id
+                        } else -1
+                    }
+                    .forEach { set.add(it) }
+            set
+        } else {
+            null
+        }
+        val timestamp = MiscUtil.getDiscordTimestamp(System.currentTimeMillis()).toString()
+        MessageHistory.getHistoryBefore(context.channel, timestamp).limit(amountToClear).queue({ history ->
+            val filtered = history.retrievedHistory
+                    .stream()
+                    .filter { msg ->
+                        (shouldAllowAll || mentioned!!.contains(msg.author.idLong))
+                                && ChronoUnit.WEEKS.between(msg.creationTime, OffsetDateTime.now()) < 2
+                    }
+                    .collect(Collectors.toList())
+            if (filtered.isEmpty()) {
+                val translated = String.format(context.getTranslated("moderation.prune.output"), 0, 0)
+                context.send("${CommandIcons.SUCCESS}$translated")
+                return@queue
+            }
+            if (filtered.size == 1) {
+                filtered.first().delete().queue({
+                    val translated = String.format(context.getTranslated("moderation.prune.output"), 1, 1)
+                    context.send("${CommandIcons.SUCCESS}$translated")
+                }) {
+                    handleError(context, it)
+                }
+                return@queue
+            }
+            context.channel.deleteMessages(filtered).queue({
+                handleSuccess(context, filtered)
+            }) {
+                handleError(context, it)
+            }
+
+        }) {
+            handleError(context, it)
+        }
+    }
+    private fun handleSuccess(context: CommandContext, filtered: List<Message>) {
+        val unique: Map<String, List<String>> = filtered
+                .stream()
+                .map { it.author.id }
+                .collect(Collectors.groupingBy { it })
+        val translated = String.format(context.getTranslated("moderation.prune.output"), filtered.size, unique.keys.size)
+        context.send("${CommandIcons.SUCCESS}$translated") {
+            it.delete().queueAfter(2, TimeUnit.SECONDS, {
+
+            }) {
+
+            }
+        }
+    }
+    private fun handleError(context: CommandContext, err: Throwable) {
+        val translated = String.format(context.getTranslated("moderation.prune.error"), err.message)
+        Sentry.capture(err)
+        context.send("${CommandIcons.ERROR}$translated")
+    }
+}

--- a/moderation/src/main/java/moe/kyokobot/moderation/commands/UnbanCommand.kt
+++ b/moderation/src/main/java/moe/kyokobot/moderation/commands/UnbanCommand.kt
@@ -1,36 +1,17 @@
 package moe.kyokobot.moderation.commands
 
 import io.sentry.Sentry
-import moe.kyokobot.bot.command.Command
-import moe.kyokobot.bot.command.CommandCategory
 import moe.kyokobot.bot.command.CommandContext
 import moe.kyokobot.bot.command.CommandIcons
-import moe.kyokobot.bot.util.CommonErrors
 import moe.kyokobot.bot.util.UserUtil
+import moe.kyokobot.moderation.ModerationCommand
 import net.dv8tion.jda.core.Permission
 
-class UnbanCommand: Command() {
+class UnbanCommand: ModerationCommand("unban", Permission.BAN_MEMBERS) {
     init {
-        name = "unban"
-        description = "moderation.unban.description"
-        usage = "moderation.unban.usage"
-        category = CommandCategory.MODERATION
         aliases = arrayOf("pardon")
     }
-
     override fun execute(context: CommandContext) {
-        if (!context.selfMember.hasPermission(Permission.BAN_MEMBERS)) {
-            CommonErrors.noPermissionBot(context, Permission.BAN_MEMBERS)
-            return
-        }
-        if (!context.member.hasPermission(Permission.BAN_MEMBERS)) {
-            CommonErrors.noPermissionUser(context)
-            return
-        }
-        if (!context.hasArgs()) {
-            CommonErrors.usage(context)
-            return
-        }
         val name = context.args[0]
         val ban = UserUtil.getBan(context.guild, name)
         if (ban == null) {
@@ -41,17 +22,16 @@ class UnbanCommand: Command() {
         val formattedName = "${ban.user.name}#${ban.user.discriminator}"
         try {
             context.guild.controller.unban(ban.user).queue({
-                val translated = String.format(context.getTranslated("moderation.unban.output"), formattedName,
-                        ban.reason ?: context.getTranslated("moderation.noreason"))
+                val translated = getTranslated(context, "output", formattedName, ban.reason ?: getTranslated(context, "noreason") ?: "No reason.")
                 context.send("${CommandIcons.SUCCESS}$translated")
             }) { err ->
                 Sentry.capture(err)
-                val error = String.format(context.getTranslated("moderation.unban.error"), formattedName, err.message)
+                val error = getTranslated(context, "error", formattedName, err.message ?: "No message.")
                 context.send("${CommandIcons.ERROR}$error")
             }
         } catch (err: Throwable) {
             Sentry.capture(err)
-            val error = String.format(context.getTranslated("moderation.unban.error"), formattedName, err.message)
+            val error = getTranslated(context, "error", formattedName, err.message ?: "No message.")
             context.send("${CommandIcons.ERROR}$error")
         }
     }


### PR DESCRIPTION
**These changes have been tested locally.**

Adds on to #34. This changes the old moderation commands so that they extend the new
`ModerationCommand` class, making dev work there a whole lot easier. This also adds some more translation strings (for the prune command).

`ky!prune [number]=15` -- Clears the last [number] messages from all members.

`ky!prune [number]=15 [member1 member2 bots]=all members*` -- Scans the last 100 messages and attempts to delete up-to [number] messages from member1, member2 and all bots in the guild (in total, not [number] each).

`ky!prune [number]=15 contains [some phrase here]` -- Scans the last 100 messages and attempts to delete up-to [number] messages that contains [some phrase here].

**`[parameters]=some_value` means the default value for the command parameters/arguments is equal to `some_value`, which also means you can leave it out and it'll automatically be `some_value`.**

`=all members*` isn't actually a valid value, but just means that all members will be targeted.