### PR TITLE
Fixed IndexOutOfBoundsException in MusicQueue

### DIFF
--- a/music/src/main/java/moe/kyokobot/music/MusicQueue.kt
+++ b/music/src/main/java/moe/kyokobot/music/MusicQueue.kt
@@ -41,7 +41,7 @@ class MusicQueue(val manager: MusicManager, val guild: Guild) {
     }
 
     fun removeDuplicates() {
-        for(i in 0 until tracks.size) {
+        for(i in 0 until tracks.size - 1) {
            if (tracks[i].audioTrack.info.identifier == tracks[i + 1].audioTrack.info.identifier) {
                tracks[i].marked = true
            }


### PR DESCRIPTION
The for-loop in removeDuplicates() would throw IndexOutOfBoundsException when called, so I added a -1 to prevent that.